### PR TITLE
Hotfix/47-jwt-cannot-refresh-token-after-expired-access-token

### DIFF
--- a/backend/src/main/java/ru/famsy/backend/modules/jwt/JwtFilter.java
+++ b/backend/src/main/java/ru/famsy/backend/modules/jwt/JwtFilter.java
@@ -48,8 +48,12 @@ public class JwtFilter extends OncePerRequestFilter {
                                   FilterChain filterChain) throws ServletException, IOException {
     try {
       String accessToken = jwtCookieService.extractTokenFromCookie(request, "access_token");
+      String refreshToken = jwtCookieService.extractTokenFromCookie(request, "refresh_token");
 
       if (accessToken == null || accessToken.isEmpty()) {
+        if (refreshToken != null && !refreshToken.isEmpty()) {
+          handleTokenRefresh(request, response);
+        }
         filterChain.doFilter(request, response);
         return;
       }

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -56,7 +56,7 @@ famsy:
   security:
     jwt:
       access-token:
-        expiration: 5m
+        expiration: 30m
       refresh-token:
         expiration: 10d
       session:


### PR DESCRIPTION
- Extended access token expiration from 5 minutes to 30 minutes.
- Initiate token refresh when access token is missing and a valid refresh token is present.

Refs: #47